### PR TITLE
Pipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /.idea/inspectionProfiles/Project_Default.xml
 /.idea/shelf/Uncommitted_changes_before_Update_at_04_04_2023,_12_46_[Changes]/shelved.patch
 /.idea
+/.idea/OS.js.iml
+/out/*
+

--- a/doc/dialog.md
+++ b/doc/dialog.md
@@ -7,7 +7,14 @@ It is a static class, so you can use it without creating an instance.
 ## Usage
     
 ```js
-Dialog.say("Hello World!");
+Dialog.globalInstance.say("Hello World!");
+```
+
+or create an instance
+
+```js
+const dialog = new Dialog();
+dialog.say("Hello World!");
 ```
 
 ## Usage within functions

--- a/doc/dialog.md
+++ b/doc/dialog.md
@@ -2,7 +2,8 @@
 
 The class responsible for outputting data to the Terminal.
 
-It is a static class, so you can use it without creating an instance.
+It has a static instance that can be used globally. Which is used for the functions in the `os.dialog` object.
+Expect if a pipe is used, that a new instance is created to be able to store the buffer.
 
 ## Usage
     

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -31,6 +31,10 @@ The Logger is a static class to log messages to the file system.
 ```bash
 jsdoc ./*
 ```
+or
+```bash
+jsdooc -r ./
+```
 
 This will generate the documentation in the `out` directory.
 Then you can open the `index.html` file in your browser.

--- a/functionLoader.js
+++ b/functionLoader.js
@@ -23,6 +23,10 @@ const os = {
      * os.dialog.ask should be used instead
      */
     ask: dialog.ask,
+    /**
+     * @deprecated
+     * os.dialog.next can be used instead, or just return
+     */
     next: dialog.next,
     logger: Logger,
     dialog: dialog,

--- a/functionLoader.js
+++ b/functionLoader.js
@@ -122,7 +122,8 @@ os.run = (data) => {
 
             if (command === '') continue;
 
-            const cmd = command + ' ' + lastOutput.join(' ');
+            const cmd = `${command} ${lastOutput.join(' ')}`
+            console.log(cmd);
             lastOutput = await runO(cmd);
         }
         resolve();

--- a/functionLoader.js
+++ b/functionLoader.js
@@ -4,10 +4,9 @@ import {AppManager} from "./appManager.js";
 import {FileSystem} from "./filesystem/FileSystem.js";
 import {Terminal} from "./terminal.js";
 
-import Fuse from 'https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.esm.js' // ToDo: use a local version instead
+import Fuse from 'https://unpkg.com/fuse.js@6.6.2/dist/fuse.esm.js' // ToDo: use a local version instead
 
-
-const dialog = Dialog;
+const dialog = Dialog.globalInstance;
 const terminal = new Terminal();
 
 const os = {
@@ -18,13 +17,13 @@ const os = {
      * @deprecated
      * os.dialog.say should be used instead
      */
-    say: Dialog.sayRaw,
+    say: dialog.sayRaw,
     /**
      * @deprecated
      * os.dialog.ask should be used instead
      */
-    ask: Dialog.ask,
-    next: Dialog.next,
+    ask: dialog.ask,
+    next: dialog.next,
     logger: Logger,
     dialog: dialog,
     fs: FileSystem.instance,
@@ -50,10 +49,13 @@ os.load = async () => {
  * Runs the command
  * @param data {string} The command to run
  */
-os.run =  (data) =>{
+const runO = (data) => {
     return new Promise(async (resolve, reject) => {
-        const args = data.trim().split(' ');
+        let args = data.trim().split(' ');
         const command = args.shift().toLowerCase();
+        let options = {
+            pipe: false,
+        };
 
         // check if the command exists
         if (!AppManager.instance.apps.has(command)) {
@@ -69,6 +71,12 @@ os.run =  (data) =>{
             }
             resolve();
             return;
+        }
+
+        // check if pipe is used
+        if (args.includes('|')) {
+            options.pipe = true;
+            args = args.filter(e => e !== '|');
         }
 
         // check if the command has the correct amount of arguments
@@ -90,10 +98,32 @@ os.run =  (data) =>{
         try {
             // run the command
             // await AppManager.instance.apps.get(command).execute(this, args);
-            await AppManager.instance.run(command, os, args);
+            const output = await AppManager.instance.run(command, os, args, options);
+            resolve(output);
         } catch (error) {
-            Dialog.next(error);
+            dialog.next(error);
             console.log(error);
+        }
+        resolve();
+    });
+}
+
+/**
+ * Split the command by | and run each command
+ * @param data {string} The commands to run
+ */
+os.run = (data) => {
+    return new Promise(async (resolve, reject) => {
+        const tmp = data.replaceAll('|', '|;:');
+        const commands = tmp.split(';:');
+        let lastOutput = [];
+
+        for (let command of commands) {
+
+            if (command === '') continue;
+
+            const cmd = command + ' ' + lastOutput.join(' ');
+            lastOutput = await runO(cmd);
         }
         resolve();
     });

--- a/functionLoader.js
+++ b/functionLoader.js
@@ -153,7 +153,6 @@ os.run = (data) => {
             if (command === '') continue;
 
             const cmd = `${command} ${lastOutput.join(' ')}`
-            console.log(cmd);
             lastOutput = await runO(cmd) ?? [];
         }
         resolve();

--- a/functionLoader.js
+++ b/functionLoader.js
@@ -84,14 +84,14 @@ const runO = (data) => {
             args = args.filter(e => e !== '|');
         }
 
-        if(args.includes('>')) {
+        if (args.includes('>')) {
             options.pipe = true;
             options.mode = ">";
             options.path = args[args.indexOf('>') + 1];
             // remove all args after the >
             args = args.slice(0, args.indexOf('>'));
         }
-        if(args.includes('>>')) {
+        if (args.includes('>>')) {
             options.pipe = true;
             options.mode = ">>";
             options.path = args[args.indexOf('>>') + 1];
@@ -120,13 +120,13 @@ const runO = (data) => {
             // await AppManager.instance.apps.get(command).execute(this, args);
             const output = await AppManager.instance.run(command, os, args, options);
 
-            if(options.mode === ">" || options.mode === ">>") {
+            if (options.mode === ">" || options.mode === ">>") {
                 const file = os.wd.getOrCreateFile(options.path);
-                if(options.mode === ">") {
+                if (options.mode === ">") {
                     file.setData(output.join('\n'));
                     resolve();
                 }
-                if(options.mode === ">>") {
+                if (options.mode === ">>") {
                     file.appendData(output.join('\n'));
                     resolve();
                 }
@@ -156,7 +156,19 @@ os.run = (data) => {
 
             if (command === '') continue;
 
-            const cmd = `${command} ${lastOutput.join(' ')}`
+            let string = "";
+
+            // find > and >>, remove them from the command and put them at the end of the generated command
+            if (command.includes('>')) {
+                string = "> " + command.split('>')[1].trim();
+                command = command.split('>')[0].trim();
+            }
+            if (command.includes('>>')) {
+                string = ">> " + command.split('>>')[1].trim();
+                command = command.split('>>')[0].trim();
+            }
+
+            const cmd = `${command} ${lastOutput.join(' ')} ${string}`
             lastOutput = await runO(cmd) ?? [];
         }
         resolve();

--- a/functions/cat.function.js
+++ b/functions/cat.function.js
@@ -6,7 +6,6 @@ export default {
     execute(os, args) {
         const path = args[0];
         const file = os.wd.getFile(path);
-        console.log(os.wd);
         if(file instanceof File) {
             os.say(file.getData());
         } else {

--- a/functions/print.function.js
+++ b/functions/print.function.js
@@ -3,6 +3,6 @@ export default {
     description: 'print [string] (print argument)',
     arguments: -1,
     execute(os, args) {
-        os.next(args.join(' '));
+        os.dialog.next(args.join(' '));
     }
 };

--- a/functions/rev.function.js
+++ b/functions/rev.function.js
@@ -2,6 +2,6 @@ export default {
     name: 'rev',
     description: 'rev [string] (print argument in reverse)',
     execute(os, args) {
-        os.next(args.join(' ').split('').reverse().join(''));
+        os.dialog.next(args.join(' ').split('').reverse().join(''));
     }
 };

--- a/functions/rev.function.js
+++ b/functions/rev.function.js
@@ -1,8 +1,7 @@
 export default {
     name: 'rev',
     description: 'rev [string] (print argument in reverse)',
-    arguments: 1,
     execute(os, args) {
-        os.next(args[0].split('').reverse().join(''));
+        os.next(args.join(' ').split('').reverse().join(''));
     }
 };

--- a/index.html
+++ b/index.html
@@ -3,16 +3,10 @@
 <head>
     <title>OS.js</title>
     <meta charset="utf-8">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="themes/style.css">
 </head>
 
 <body>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
-        crossorigin="anonymous"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="kernel.js" onload="boot();"></script>
 <script src="./filesystem/FileSystem.js" type="module"></script>
 

--- a/kernel.js
+++ b/kernel.js
@@ -11,6 +11,7 @@ async function boot() {
     await initFilesystem(); // load the filesystem
     await initInputManager(); //load the input manager
     await initAppManager(); //load the app manager
+    await initDialog(); //load the dialog
     setup();
     await functionLoaderInit();
 
@@ -45,6 +46,11 @@ async function initAppManager() {
     const {AppManager} = await import('./appManager.js');
     appManager = new AppManager();
     await appManager.load();
+}
+
+async function initDialog() {
+    const {Dialog} = await import('./utils/dialog.js');
+    Dialog.globalInstance = new Dialog();
 }
 
 /**

--- a/terminal.js
+++ b/terminal.js
@@ -49,6 +49,8 @@ export class Terminal {
             return Terminal.instance;
         }
 
+        CommandLine.terminal = this;
+
         // Saves the session
         // Terminal.sessions.push(this);
     }
@@ -58,7 +60,7 @@ export class Terminal {
      * @returns {Promise<void>}
      */
     async init() {
-        Dialog.say("Welcome to the terminal");
+        Dialog.globalInstance.say("Welcome to the terminal");
         this.loadHistory();
         await this.loop();
     }
@@ -114,14 +116,14 @@ export class Terminal {
     async loop() {
         while (true) {
             this.historyPointer = this.history.length;
-            const input = await Dialog.ask(`${this.wd.getPathAsString() || ""} >`, {autoComplete: "apps", history: true});
+            const input = await Dialog.globalInstance.ask(`${this.wd.getPathAsString() || ""} >`, {autoComplete: "apps", history: true});
             try {
                 // save output of last command
                 this.pushHistory(input);
                 await functionLoader.run(input);
             } catch (e) {
                 console.log(e);
-                Dialog.say(e.message);
+                Dialog.globalInstance.say(e.message);
             }
         }
     }


### PR DESCRIPTION
### Pipes & Stuff

#### Now Presenting:
`|`, `>` & `>>`

`time | rev > time.txt`
-> take the current time, reverse the direction of the time and write it to the file `time.txt`


This pull request adds the feature to use the pipe "|" in the terminal to use the output of the left function as argument for the right function.

This also adds the option to use "<" and "<<" to write content to a file.

### Important
It only works if the functions use `os.dialog.say` instead of `os.say`.

<br>

closes #7 

#### Breaking Changes:
The Dialog Class is not static anymore, this was necessary to overwrite the output of single functions for the pipe.
Instead a `Dialog.globalInstance` is available to be able to use a static instance of the class

Nothings changes for functions, `os.dialog` behaves the same